### PR TITLE
sl/check-property: avoid truncating output file

### DIFF
--- a/sl/check-property.sh.in
+++ b/sl/check-property.sh.in
@@ -470,7 +470,7 @@ if [ -z $ENABLE_LLVM ]; then
         -fplugin="${SL_PLUG}"                           \
         -fplugin-arg-libsl-args="$ARGS"                 \
         -o /dev/null -O0 -S -xc "$SRC_FILE" $CFLAGS 2>&1 \
-        | tee "$TRACE"                                  \
+        | tee -a "$TRACE"                                  \
         | parse_output
 else
     "$CLANG_HOST" -S -emit-llvm -O0 -g -o -             \
@@ -480,7 +480,7 @@ else
         -load "$PASSES_LIB" -global-vars -nestedgep     \
         -load "$SL_PLUG" -sl -args="$ARGS"              \
         -o /dev/null 2>&1                               \
-        | tee "$TRACE"                                  \
+        | tee -a "$TRACE"                                  \
         | parse_output
 fi
 


### PR DESCRIPTION
If stdout of check-property is redirected to a file to capture result report and/or compiler output, it is later truncated by tee unless -a flag is specified. This commit makes it possible to properly parse output of check-property.sh e.g. in benchexec.