### PR TITLE
sl/check-property: ignore unreachable label

### DIFF
--- a/sl/check-property.sh.in
+++ b/sl/check-property.sh.in
@@ -5,6 +5,8 @@ export CCACHE_DISABLE=1
 
 export MSG_INFLOOP=': warning: end of function .*\(\) has not been reached'
 export MSG_LABEL_FOUND=': error: error label "ERROR" has been reached'
+export MSG_LABEL_UNREACHABLE=': warning: unreachable label .*'
+export MSG_WARNINGS_REPORTED=': warning: Pass has reported some warnings'
 export MSG_VERIFIER_ERROR_FOUND=': (error|warning): __VERIFIER_error\(\) reached'
 export MSG_OUR_WARNINGS=': warning: .*(\[-fplugin=libsl.so\]|\[-sl\])$'
 export MSG_TIME_ELAPSED=': note: clEasyRun\(\) took '
@@ -420,8 +422,12 @@ parse_output() {
             fail "$line"
 
         elif match "$line" "$MSG_INFLOOP" || \
+             match "$line" "$MSG_WARNINGS_REPORTED" || \
+             match "$line" "$MSG_LABEL_UNREACHABLE" || \
              match "$line" "$MSG_INTERVAL_REDUCE"; then
             # infinite loop does not mean FALSE
+            # reported warnings could be one of the ignored
+            # unreachable label is not reason to fail
             # interval reduce only for huters too, ignore them
             continue #why continue in elif?
 


### PR DESCRIPTION
Unreachable label caused the script to fail with "unknown" result. This commit marks the warning as ignored. To ignore the warning completely and produce correct result, the warning that mentions other warnings must be ignored too.