### PR TITLE
sl/check-property: run also nameblocks with LLVM

### DIFF
--- a/sl/check-property.sh.in
+++ b/sl/check-property.sh.in
@@ -477,7 +477,7 @@ else
         -Xclang -fsanitize-address-use-after-scope      \
         "$SRC_FILE" $CFLAGS                             \
         | "$OPT_HOST" -lowerswitch                      \
-        -load "$PASSES_LIB" -global-vars -nestedgep     \
+        -load "$PASSES_LIB" -global-vars -nestedgep -nameblocks     \
         -load "$SL_PLUG" -sl -args="$ARGS"              \
         -o /dev/null 2>&1                               \
         | tee "$TRACE"                                  \


### PR DESCRIPTION
The pass names all blocks in program. The pass is added in VeriFIT/ProStatA#6 .