### PR TITLE
cl/llvm: allow function cast under some conditions

### DIFF
--- a/cl/llvm/clplug.cc
+++ b/cl/llvm/clplug.cc
@@ -2021,14 +2021,14 @@ bool CLPass::handleCastOperand(Value *v, struct cl_operand *src) {
 
         if (srcTy && destTy) {
             bool safe = (destTy->getNumParams() == srcTy->getNumParams());
-            for (auto i = 0; i < destTy->getNumParams() && safe; ++i) {
+            for (unsigned i = 0; i < destTy->getNumParams() && safe; ++i) {
                 safe &= (destTy->getParamType(i) == srcTy->getParamType(i));
             }
 
             safe &= (destTy->getReturnType() == srcTy->getReturnType());
 
             if (safe) {
-                return handleOperand(I->getOperand(0), src);
+                return notEmptyAcc;
             }
         }
 

--- a/cl/llvm/clplug.cc
+++ b/cl/llvm/clplug.cc
@@ -2016,6 +2016,22 @@ bool CLPass::handleCastOperand(Value *v, struct cl_operand *src) {
     bool notEmptyAcc = handleOperand(I->getOperand(0), src);
 
     if (src->type->code == CL_TYPE_FNC) {
+        auto* srcTy = dyn_cast_or_null<FunctionType>(I->getSrcTy()->getPointerElementType());
+        auto* destTy = dyn_cast_or_null<FunctionType>(I->getDestTy()->getPointerElementType());
+
+        if (srcTy && destTy) {
+            bool safe = (destTy->getNumParams() == srcTy->getNumParams());
+            for (auto i = 0; i < destTy->getNumParams() && safe; ++i) {
+                safe &= (destTy->getParamType(i) == srcTy->getParamType(i));
+            }
+
+            safe &= (destTy->getReturnType() == srcTy->getReturnType());
+
+            if (safe) {
+                return handleOperand(I->getOperand(0), src);
+            }
+        }
+
         CL_ERROR("unsupport cast from function type");
         return false;
     }


### PR DESCRIPTION
The function pointer cast is allowed in case the function types have the same return type and corresponding parameter types. This allows function pointer to be stripped when casting e.g. `void (...)` to `void ()`.