### PR TITLE
cl/llvm: erase deleted value from VarTable

### DIFF
--- a/cl/llvm/clplug.cc
+++ b/cl/llvm/clplug.cc
@@ -1314,6 +1314,8 @@ bool CLPass::handleOperand(Value *v, struct cl_operand *clo) {
 #else
                 delete vi;
 #endif
+                // do not allow re-use of vi as it's no longer valid
+                VarTable.erase(vi);
                 return retHO;
             }
 #ifdef LLVM_HOST_6_OR_NEWER
@@ -1321,6 +1323,7 @@ bool CLPass::handleOperand(Value *v, struct cl_operand *clo) {
 #else
             delete vi;
 #endif
+            VarTable.erase(vi);
 
         } else {                          // just constant
             handleBasicConstant(v, clo);


### PR DESCRIPTION
Keeping the value sometimes causes CL to re-use the value when it's no longer valid.

For example here:
```c
struct S {  int i;  };

struct S a, b;

int main() {
    a = b;
    return 0;
}
```

The assignment `a = b` is compiled by clang to `llvm.memcpy(bitcast @a to i8*, bitcast @b to i8*, 4, false)`. cl-llvm (incorrectly) reuses the value of `bitcast @a to i8*` so it becomes:
```
%R15 = a
%R16 = b
memcpy(%R15,%R15)
```