### PR TITLE
sl/symproc: skip varkill if next block is abort

### DIFF
--- a/sl/symproc.cc
+++ b/sl/symproc.cc
@@ -1020,6 +1020,7 @@ bool headingToAbort(const CodeStorage::Block *bb)
     const CodeStorage::Insn *term = bb->back();
     const cl_insn_e code = term->code;
 
+    // when the abort is below a label, an extra block may precede it
     if (CL_INSN_JMP == code) {
         const CodeStorage::TTargetList target = term->targets;
         const CodeStorage::Insn *targetTerm = target[0]->back();

--- a/sl/symproc.cc
+++ b/sl/symproc.cc
@@ -1019,6 +1019,14 @@ bool headingToAbort(const CodeStorage::Block *bb)
 {
     const CodeStorage::Insn *term = bb->back();
     const cl_insn_e code = term->code;
+
+    if (CL_INSN_JMP == code) {
+        const CodeStorage::TTargetList target = term->targets;
+        const CodeStorage::Insn *targetTerm = target[0]->back();
+
+        return (CL_INSN_ABORT == targetTerm->code);
+    }
+
     return (CL_INSN_ABORT == code);
 }
 


### PR DESCRIPTION
this helps in cases where the abort call is below a label